### PR TITLE
don't force options.objectMode = true;

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
   }
 
   options = options || {};
-  options.objectMode = true;
 
   stream.Duplex.call(this, options);
 


### PR DESCRIPTION
not all duplexed streams are object mode.

the objectmode could probably be propagated from writable&readable if needed
