### PR TITLE
set engine minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   "devDependencies": {
     "chai": "~1.7.2",
     "mocha": "~1.12.1"
-  }
+  },
+  "engines": {
+    "node": ">=0.9"
+  },
+  "engineStrict": true
 }


### PR DESCRIPTION
people have issues all the time with this. they install it on 0.6 and get an obscure error because Stream.Duplex doesn't exist
