### PR TITLE
Properly export DuplexWrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var stream = require("readable-stream");
 
-var duplex2 = module.exports = function duplex2(options, writable, readable) {
+var duplex2 = exports = module.exports = function duplex2(options, writable, readable) {
   return new DuplexWrapper(options, writable, readable);
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -19,6 +19,10 @@ describe("duplexer2", function() {
     };
   });
 
+  it("should export the DuplexWrapper constructor", function(){
+    assert.isFunction(duplexer2.DuplexWrapper);
+  });
+
   it("should interact with the writable stream properly for writing", function(done) {
     var duplex = duplexer2(writable, readable);
 


### PR DESCRIPTION
It seems like this was intended to be exported, so I guess this is a bug, rather than a feature.