### PR TITLE
Remove unnecessary props on duplexer instance and remove strict type check

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,28 +6,13 @@ var Duplex = stream.Duplex;
 var Readable = stream.Readable;
 
 var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writable, readable) {
-  if (readable === undefined) {
+  if (typeof readable === "undefined") {
     readable = writable;
     writable = options;
-    options = {};
-  } else {
-    options = options || {};
+    options = null;
   }
 
   Duplex.call(this, options);
-
-  if (options.bubbleErrors === undefined) {
-    this._bubbleErrors = true;
-  } else {
-    if (typeof options.bubbleErrors !== "boolean") {
-      throw new TypeError(
-        String(options.bubbleErrors) +
-        " is not a Boolean value. `bubbleErrors` option of duplexer2 must be Boolean (`true` by default)."
-      );
-    }
-    this._bubbleErrors = options.bubbleErrors;
-  }
-  this._shouldRead = false;
 
   if (typeof readable.read !== "function") {
     readable = (new Readable()).wrap(readable);
@@ -56,7 +41,7 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
     return self.push(null);
   });
 
-  if (this._bubbleErrors) {
+  if (!options || typeof options.bubbleErrors === "undefined" || options.bubbleErrors) {
     writable.on("error", function(err) {
       return self.emit("error", err);
     });

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ class FixtureWritable extends Writable {
 }
 
 test("duplexer2", t => {
-  t.plan(11);
+  t.plan(10);
 
   duplexer2(
     new FixtureWritable({
@@ -129,10 +129,4 @@ test("duplexer2", t => {
   });
 
   stream1.push("well hello there");
-
-  t.throws(
-    () => duplexer2({bubbleErrors: 1}, new Writable(), new Readable()),
-    /TypeError.*1 is not a Boolean value\./,
-    "should throw a type error when it takes `bubbleError` option but it's not Boolean"
-  );
 });


### PR DESCRIPTION
Also, please consider:

1. Making the lint check run _after_ the tests. It makes it really hard to test things fast when the running the tests fails because you missed a space.

2. Switching the tests back to ES5. Transpiling adds another layer of complexity when debugging this package. It makes running the tests through node-inspector more difficult.