### PR TITLE
Consistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,16 +50,16 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
   });
 
   readable.once("end", function() {
-    return self.push(null);
+    self.push(null);
   });
 
   if (this._bubbleErrors) {
     writable.on("error", function(err) {
-      return self.emit("error", err);
+      self.emit("error", err);
     });
 
     readable.on("error", function(err) {
-      return self.emit("error", err);
+      self.emit("error", err);
     });
   }
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var stream = require("readable-stream");
 
-var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writable, readable) {
+function DuplexWrapper(options, writable, readable) {
   if (readable === undefined) {
     readable = writable;
     writable = options;
@@ -62,7 +62,7 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
       self.emit("error", err);
     });
   }
-};
+}
 
 DuplexWrapper.prototype = Object.create(stream.Duplex.prototype, {constructor: {value: DuplexWrapper}});
 
@@ -77,3 +77,5 @@ DuplexWrapper.prototype._read = function _read() {
 module.exports = function duplex2(options, writable, readable) {
   return new DuplexWrapper(options, writable, readable);
 };
+
+module.exports.DuplexWrapper = DuplexWrapper;

--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@
 
 var stream = require("readable-stream");
 
-var Duplex = stream.Duplex;
-var Readable = stream.Readable;
-
 var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writable, readable) {
   if (readable === undefined) {
     readable = writable;
@@ -14,7 +11,7 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
     options = options || {};
   }
 
-  Duplex.call(this, options);
+  stream.Duplex.call(this, options);
 
   if (options.bubbleErrors === undefined) {
     this._bubbleErrors = true;
@@ -30,7 +27,7 @@ var DuplexWrapper = exports.DuplexWrapper = function DuplexWrapper(options, writ
   this._shouldRead = false;
 
   if (typeof readable.read !== "function") {
-    readable = (new Readable()).wrap(readable);
+    readable = (new stream.Readable()).wrap(readable);
   }
 
   this._writable = writable;


### PR DESCRIPTION
* `stream.Duplex.prototype` was already used, and it's clearer to read that `Duplex` and `Readable` are on the `stream` object.

* Although the expose of `DuplexWrapper` never worked, it's handy to have.