### PR TITLE
Propagate options when wrapping a readable stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function DuplexWrapper(options, writable, readable) {
   stream.Duplex.call(this, options);
 
   if (typeof readable.read !== "function") {
-    readable = (new stream.Readable()).wrap(readable);
+    readable = (new stream.Readable(options)).wrap(readable);
   }
 
   this._writable = writable;


### PR DESCRIPTION
Especially useful to work with object streams (propagating the `objectMode` option).

Otherwise I had an `Invalid non-string/buffer chunk` error in case the readable stream needed to be wrapped.