### PR TITLE
Add .obj shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Options
 * __bubbleErrors__ - a boolean value that specifies whether to bubble errors
   from the underlying readable/writable streams. Default is `true`.
 
+### duplexer2.obj
+
+Creates a new `DuplexWrapper` object in the object mode. The arguments and options are the same as the above.
+
+```javascript
+duplexer2.obj([options], writable, readable)
+```
+
+```javascript
+const duplex = duplexer2.obj(new stream.Writable({objectMode: true}), new stream.Readable({objectMode: true}));
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -73,4 +73,21 @@ module.exports = function duplex2(options, writable, readable) {
   return new DuplexWrapper(options, writable, readable);
 };
 
+module.exports.obj = function (options, writable, readable) {
+  if (typeof readable === "undefined") {
+    readable = writable;
+    writable = options;
+    options = {};
+  }
+
+  if (!options) {
+    options = {}
+  }
+
+  options.objectMode = true
+  options.highWaterMark = options.highWaterMark || 16
+
+  return module.exports(options, writable, readable)
+};
+
 module.exports.DuplexWrapper = DuplexWrapper;

--- a/test/tests.js
+++ b/test/tests.js
@@ -220,4 +220,42 @@ describe("duplexer2", function() {
       assert.equal(readable._readableState.flowing, null);
     });
   });
+
+  describe('.obj', function() {
+    it('should create duplex of object mode', function(done) {
+      var duplex = duplexer2.obj(null, writable, readable);
+
+      duplex.on('data', function(data) {
+        assert.deepEqual(data, {message: "hello"});
+
+        done()
+      });
+
+      writable._write = function _write(input, encoding, _done) {
+        assert.deepEqual(input, {message: "hello"});
+
+        readable.push(input);
+      };
+
+      duplex.write({message: "hello"});
+    });
+
+    it('should work with the default options when the first param is omitted', function(done) {
+      var duplex = duplexer2.obj(writable, readable);
+
+      duplex.on('data', function(data) {
+        assert.deepEqual(data, {message: "hello"});
+
+        done()
+      });
+
+      writable._write = function _write(input, encoding, _done) {
+        assert.deepEqual(input, {message: "hello"});
+
+        readable.push(input);
+      };
+
+      duplex.write({message: "hello"});
+    });
+  });
 });


### PR DESCRIPTION
Like through2 or duplexify does, it's nice to have `.obj` shorthand for creating streams in the object mode.