### PR TITLE
Update README.md (note on setting objectMode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ writable.once("finish", function() {
   }, 500);
 });
 
-var duplex = duplexer2(writable, readable);
+// set objectMode to match the writable and readable streams
+var duplex = duplexer2({objectMode: true}, writable, readable);
 
 duplex.on("data", function(e) {
   console.log("got data", JSON.stringify(e));


### PR DESCRIPTION
changed the call to duplexer2() in the example, and added a comment indicating that its objectMode option should be set to match the writable and readable streams